### PR TITLE
Also stop propagation of key events to other listeners.

### DIFF
--- a/keypress.coffee
+++ b/keypress.coffee
@@ -70,7 +70,8 @@ _prevent_default = (e, should_prevent) ->
     # one, we should prevent the default keydown event.
     if (should_prevent or keypress.suppress_event_defaults) and not keypress.force_event_defaults
         e.preventDefault()
-        e.stopPropagation()
+        if e.stopPropagation
+            e.stopPropagation()
 
 _allow_key_repeat = (combo) ->
     return false if combo.prevent_repeat


### PR DESCRIPTION
I'm using Keypress on a Chrome extension, and encountered the problem that mapped keystrokes are being passed to the underlying web page.

This PR fixes that.

Thanks!
