### PR TITLE
Fix IE9-10 readyState bug

### DIFF
--- a/keypress.coffee
+++ b/keypress.coffee
@@ -739,11 +739,11 @@ for _, key of _keycode_shifted_keys
 _init()
 
 _ready = (callback) ->
-    if /loading/.test document.readyState
+    if ((if document.attachEvent then document.readyState is "complete" else document.readyState isnt "loading"))
+        callback()
+    else
         setTimeout ->
             _ready callback
         , 9
-    else
-        callback()
 
 _ready _bind_key_events


### PR DESCRIPTION
interactive readyState is fired too quickly in IE9-10, then wait complete for IE
