### PR TITLE
Added another keycode for 'alt'

### DIFF
--- a/keypress.coffee
+++ b/keypress.coffee
@@ -773,6 +773,7 @@ _keycode_dictionary =
     222 : "\'"
     223 : "`"
     224 : "cmd"
+    225 : "alt"
     # Opera weirdness
     57392   : "ctrl"
     63289   : "num"


### PR DESCRIPTION
Firefox 24 on Linux x64 reports the right Alt key (Alt Gr on some
keyboards) as keycode 225. I've added 225 to the keycode dictionary.
