### PR TITLE
unregister_many can use the results of register_many to unregister combos

### DIFF
--- a/keypress.coffee
+++ b/keypress.coffee
@@ -535,7 +535,7 @@ class keypress.Listener
         
         if _validate_combo combo
             @_registered_combos.push combo
-            return true
+            combo
 
     register_many: (combo_array) ->
         @register_combo(combo) for combo in combo_array

--- a/test/tests.coffee
+++ b/test/tests.coffee
@@ -785,6 +785,29 @@ describe "APIs behave as expected:", ->
     afterEach ->
         listener.reset()
 
+    describe "unregister_many", ->
+        it "unregisters the combos registered by register_many", () ->
+            combos1 = [ {
+                keys : "shift s",
+            }, {
+                keys : "shift r",
+            }]
+            combos2 = [ {
+                keys : "alt s"
+            }, {
+                keys : "alt r"
+            }]
+
+            registered1 = listener.register_many(combos1)
+            registered2 = listener.register_many(combos2)
+            expect(listener.get_registered_combos().length).toEqual(4)
+            listener.unregister_many(registered2)
+            expect(listener.get_registered_combos().length).toEqual(2)
+            expect(listener.get_registered_combos()[0].keys).toEqual(["shift", "s"])
+            expect(listener.get_registered_combos()[1].keys).toEqual(["shift", "r"])
+
+
+
     describe "unregister_combo", ->
 
         it "unregisters string", ->


### PR DESCRIPTION
It would be nice to allow unregister_many to undo the results of register_many by just feeding the results of register_many back into it:

<pre>
  registered1 = listener.register_many(some_combos)
  registered2 = listener.register_many(some_other_combos)

  listener.unregister_many(registered1) // now listener only has some_other_combos registered
</pre>

I just made a simple change where register_combo returns the combo object instead of "true" - is that OK? A cursory glance didn't show anyplace where the return value of register_combo is needed/used.

I added a test as well that exercises the functionality.

I love the library overall - it's been really helpful for my projects!  
