### PR TITLE
Load jQuery when browsing https

### DIFF
--- a/index.html
+++ b/index.html
@@ -629,7 +629,7 @@ stop_listening(); // Stop listening for combos until listen() is called again</c
         </div>
     </div>
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script>
     
     <script src="./js/main.js"></script>
     <script src="./js/highlight.js"></script>


### PR DESCRIPTION
jQuery wasn't loading when browsing https.  This should fix it.
