### PR TITLE
fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ released under the Apache License, version 2.0
 * Another fix for unregistering combos using an array of keys
 * Added a destroy method to cleanup a listener. Thanks to [smerickson](https://github.com/smerickson) for submitting. [Pull request #51](https://github.com/dmauro/Keypress/pull/51)
 * Fixed compatibility for '-'/'_' and '='/'+' keys in FireFox. Thanks to [simonsarris](https://github.com/simonsarris) for spotting the bug. [Issue #50](https://github.com/dmauro/Keypress/issues/50)
-* Added []spm support](http://spmjs.io/package/keypress). Thanks to [sorrycc](https://github.com/sorrycc). [Pull request #52](https://github.com/dmauro/Keypress/pull/52)
+* Added [spm support](http://spmjs.io/package/keypress). Thanks to [sorrycc](https://github.com/sorrycc). [Pull request #52](https://github.com/dmauro/Keypress/pull/52)
 
 2.0.3
 


### PR DESCRIPTION
Note: you still have to fix the same typo in your description of the [release v2.1.0](https://github.com/dmauro/Keypress/releases/tag/2.1.0).