### PR TITLE
Correcting keycodes for "-" and "=" in Gecko. They were switched.

### DIFF
--- a/keypress.coffee
+++ b/keypress.coffee
@@ -897,8 +897,8 @@ _keycode_dictionary =
     63289   : "num"
     # Firefox weirdness
     59 : ";"
-    61 : "-"
-    173 : "="
+    61 : "="
+    173 : "-"
 
 # For testing only:
 keypress._keycode_dictionary = _keycode_dictionary

--- a/keypress.js
+++ b/keypress.js
@@ -1107,8 +1107,8 @@ Combo options available and their defaults:
     57392: "ctrl",
     63289: "num",
     59: ";",
-    61: "-",
-    173: "="
+    61: "=",
+    173: "-"
   };
 
   keypress._keycode_dictionary = _keycode_dictionary;


### PR DESCRIPTION
Bug causes zooming in and out in Firefox to switch from Webkit. Not sure if there's a build procedure you need done here, but this should correct the problem.